### PR TITLE
Add hatchling build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ email = "support@rememberizer.ai"
 requires = [ "hatchling",]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/mcp_server_rememberizer"]
+
 [dependency-groups]
 dev = [
     "pyright>=1.1.389",


### PR DESCRIPTION
## Overview
This PR adds wheel build target configuration to pyproject.toml to specify the package location.

## Changes
- Add `[tool.hatch.build.targets.wheel]` section to specify `src/mcp_server_rememberizer` as the package directory
- Ensures proper package discovery during wheel building